### PR TITLE
use official Travis-CI D support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,2 @@
 language: d
-script: dub test
-
-install:
-  # dmd
-  # dub
-  - DMD_VER=2.065.0
-  - DMD=dmd_${DMD_VER}-0_amd64.deb
-  - DUB_VER=0.9.21
-  - DUB=dub-${DUB_VER}-linux-x86_64
-  - wget http://downloads.dlang.org/releases/2014/${DMD}
-  - sudo dpkg -i ${DMD} || true
-  - sudo apt-get -y update
-  - sudo apt-get -fy install
-  - sudo dpkg -i ${DMD}
-  - wget http://code.dlang.org/files/${DUB}.tar.gz
-  - sudo tar -C /usr/local/bin -zxf ${DUB}.tar.gz
+sudo: false


### PR DESCRIPTION
- see http://docs.travis-ci.com/user/languages/d/
- use `sudo: false` for container based infrastructure